### PR TITLE
Fix NULL error

### DIFF
--- a/easy_inspector_195065185/lua/weapons/gmod_tool/stools/rb655_easy_inspector.lua
+++ b/easy_inspector_195065185/lua/weapons/gmod_tool/stools/rb655_easy_inspector.lua
@@ -671,7 +671,7 @@ if ( SERVER ) then
 	net.Receive( "rb655_inspector_reqinfo", function( msglen, ply )
 		local ent = net.ReadEntity()
 
-		if ( !IsValid( ent:GetPhysicsObject() ) ) then return end
+		if ( !IsValid(ent) or !IsValid( ent:GetPhysicsObject() ) ) then return end
 
 		local data = { data = {}, model = ent:GetModel(), class = ent:GetClass(), entid = ent:EntIndex() }
 		for i = 0, ent:GetPhysicsObjectCount() - 1 do


### PR DESCRIPTION
Fixes:
```
[Easy Entity Inspector] lua/weapons/gmod_tool/stools/rb655_easy_inspector.lua:674: Tried to use a NULL entity!
1. GetPhysicsObject - [C]:-1
 2. func - lua/weapons/gmod_tool/stools/rb655_easy_inspector.lua:674
  3. unknown - lua/includes/extensions/net.lua:34
```
If a player sends a invalid entity, then BOOM, we get an error