### PR TITLE
Fix bad dupes lua error

### DIFF
--- a/extended_properties_104607712/lua/autorun/rb655_ext_props_wpn_slct.lua
+++ b/extended_properties_104607712/lua/autorun/rb655_ext_props_wpn_slct.lua
@@ -12,7 +12,7 @@ local extraItems = {
 local allWeapons = CreateConVar( "rb655_ext_properties_npcallweapons", "1", FCVAR_ARCHIVE + FCVAR_REPLICATED, "Whether 'Change Weapon' property should list all weapons (even if they are not compatible with NPCs), or only those specifically marked as compatible with NPCs." )
 
 local function GiveWeapon( ply, ent, args )
-	if ( !args or !args[ 1 ] or !isstring( args[ 1 ] ) ) then return end
+	if ( !ent:IsNPC() or !args or !args[ 1 ] or !isstring( args[ 1 ] ) ) then return end
 
 	local className = args[ 1 ]
 


### PR DESCRIPTION
Bad dupes may contain modifiers on non-NPCs, causing an error
```
- attempt to call method 'Give' (a nil value)
1. ModFunction - lua/autorun/rb655_ext_props_wpn_slct.lua:46
 2. ApplyEntityModifiers - lua/includes/modules/duplicator.lua:902
  3. Receive - lua/autorun/rb655_make_animatable.lua:79
   4. func - lua/includes/modules/properties.lua:185
    5. <unknown> - lua/includes/extensions/net.lua:34
```