### PR TITLE
Make `prop_animatable` outline respect depth

### DIFF
--- a/easy_animation_104604709/lua/entities/prop_animatable.lua
+++ b/easy_animation_104604709/lua/entities/prop_animatable.lua
@@ -236,9 +236,9 @@ function ENT:DrawBBox()
 	local maxs = self:OBBMaxs()
 
 	if ( self:GetSolid() == SOLID_BBOX ) then
-		render.DrawWireframeBox( self:GetPos(), angle_zero, mins, maxs )
+		render.DrawWireframeBox( self:GetPos(), angle_zero, mins, maxs, true )
 	else
-		render.DrawWireframeBox( self:GetPos(), self:GetAngles(), mins, maxs )
+		render.DrawWireframeBox( self:GetPos(), self:GetAngles(), mins, maxs, true )
 	end
 
 end


### PR DESCRIPTION
The outline can be rendered across the entire map simply because the entity is in PVS, this is a bit bad for servers, so i suggest taking depth into account